### PR TITLE
Fix: Add proper MIME type configuration for JavaScript modules in Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,9 +6,38 @@
   "framework": "vite",
   "routes": [
     {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/assets/(.*)",
+      "headers": {
+        "cache-control": "public, max-age=31536000, immutable",
+        "content-type": "application/javascript"
+      }
+    },
+    {
       "src": "/(.*)",
-      "dest": "/"
+      "dest": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).js",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/javascript; charset=utf-8"
+        }
+      ]
     }
   ]
 }
-


### PR DESCRIPTION
This PR fixes the MIME type issue that was causing JavaScript modules not to load properly in the deployed application.

Changes made:
- Added proper MIME type configurations in vercel.json
- Configured correct Content-Type headers for JavaScript files
- Added filesystem handling and caching configurations
- Set up proper routing for the Vite application

This should resolve the error:
"Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of text/html"