### PR TITLE
Fix: Add proper MIME type configuration for JavaScript modules in Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,23 +4,26 @@
   "outputDirectory": "dist",
   "installCommand": "npm install",
   "framework": "vite",
-  "routes": [
+  "rewrites": [
     {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/assets/(.*)",
-      "headers": {
-        "cache-control": "public, max-age=31536000, immutable",
-        "content-type": "application/javascript"
-      }
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ],
   "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "Content-Type",
+          "value": "application/javascript; charset=utf-8"
+        }
+      ]
+    },
     {
       "source": "/(.*)",
       "headers": [


### PR DESCRIPTION
This PR fixes the Vercel deployment configuration issues:
   
   - Removes conflicting `routes` configuration
   - Uses `rewrites` instead (Vercel's recommended approach)
   - Maintains proper MIME type configurations
   - Sets up correct caching and content-type headers
   
   This should resolve both:
   1. The MIME type error for JavaScript modules
   2. The Vercel configuration error about routes and headers conflic