### PR TITLE
Fix: remove incorrect Content-Type headers causing MIME errors

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,32 +12,11 @@
   ],
   "headers": [
     {
-      "source": "/assets/(.*)\\.css",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        },
-        {
-          "key": "Content-Type",
-          "value": "text/css; charset=utf-8"
-        },
-        {
-          "key": "X-Content-Type-Options",
-          "value": "nosniff"
-        }
-      ]
-    },
-    {
       "source": "/assets/(.*)",
       "headers": [
         {
           "key": "Cache-Control",
           "value": "public, max-age=31536000, immutable"
-        },
-        {
-          "key": "Content-Type",
-          "value": "application/javascript; charset=utf-8"
         }
       ]
     },
@@ -47,15 +26,6 @@
         {
           "key": "X-Content-Type-Options",
           "value": "nosniff"
-        }
-      ]
-    },
-    {
-      "source": "/(.*).js",
-      "headers": [
-        {
-          "key": "Content-Type",
-          "value": "application/javascript; charset=utf-8"
         }
       ]
     }


### PR DESCRIPTION
Removed explicit 'Content-Type' headers from vercel.json that were incorrectly forcing .css files to be served as 'application/javascript'. This caused the deployed app to break due to strict MIME checking. Retained caching and security headers only.